### PR TITLE
Fix Boost Include Path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ FIND_PACKAGE (Boost COMPONENTS system filesystem REQUIRED)
 
 if (Boost_FOUND)
   include_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${Boost_INCLUDE_DIRS}
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,13 @@ endif()
 
 FIND_PACKAGE (Boost COMPONENTS system filesystem REQUIRED)
 
+if (Boost_FOUND)
+  include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${Boost_INCLUDE_DIRS}
+    )
+endif()
+
 AUX_SOURCE_DIRECTORY(src/ vcparser_SRC)
 AUX_SOURCE_DIRECTORY(src/vcx vcparser_SRC)
 AUX_SOURCE_DIRECTORY(src/cmake vcparser_SRC)


### PR DESCRIPTION
 fatal error:
      'boost/filesystem.hpp' file not found
#include <boost/filesystem.hpp>
         ^
1 error generated.